### PR TITLE
Expand to include Spark 2.4.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,36 @@ matrix:
 
   - services: docker
     env:
+    - SPARK_VERSION=2.4.1
+    - HADOOP_VERSION=3.1.0
+    - AWS_JAVA_SDK_VERSION=1.11.271
+    - WITH_HIVE=true
+    - WITH_PYSPARK=true
+    - DIST=debian
+
+  - services: docker
+    env:
+    - SPARK_VERSION=2.4.1
+    - HADOOP_VERSION=2.7.3
+    - AWS_JAVA_SDK_VERSION=1.7.4
+    - WITH_HIVE=true
+    - WITH_PYSPARK=true
+    - DIST=debian
+
+  - services: docker
+    env:
     - SPARK_VERSION=2.4.0
     - HADOOP_VERSION=3.1.0
     - AWS_JAVA_SDK_VERSION=1.11.271
+    - WITH_HIVE=true
+    - WITH_PYSPARK=true
+    - DIST=debian
+
+  - services: docker
+    env:
+    - SPARK_VERSION=2.4.0
+    - HADOOP_VERSION=2.7.3
+    - AWS_JAVA_SDK_VERSION=1.7.4
     - WITH_HIVE=true
     - WITH_PYSPARK=true
     - DIST=debian
@@ -119,6 +146,33 @@ matrix:
   - services: docker
     env:
     - SPARK_VERSION=2.1.0
+    - HADOOP_VERSION=2.7.3
+    - AWS_JAVA_SDK_VERSION=1.7.4
+    - WITH_HIVE=true
+    - WITH_PYSPARK=true
+    - DIST=debian
+
+  - services: docker
+    env:
+    - SPARK_VERSION=2.0.2
+    - HADOOP_VERSION=2.7.3
+    - AWS_JAVA_SDK_VERSION=1.7.4
+    - WITH_HIVE=true
+    - WITH_PYSPARK=true
+    - DIST=debian
+
+  - services: docker
+    env:
+    - SPARK_VERSION=2.0.1
+    - HADOOP_VERSION=2.7.3
+    - AWS_JAVA_SDK_VERSION=1.7.4
+    - WITH_HIVE=true
+    - WITH_PYSPARK=true
+    - DIST=debian
+
+  - services: docker
+    env:
+    - SPARK_VERSION=2.0.0
     - HADOOP_VERSION=2.7.3
     - AWS_JAVA_SDK_VERSION=1.7.4
     - WITH_HIVE=true
@@ -129,9 +183,36 @@ matrix:
 
   - services: docker
     env:
+    - SPARK_VERSION=2.4.1
+    - HADOOP_VERSION=3.1.0
+    - AWS_JAVA_SDK_VERSION=1.11.271
+    - WITH_HIVE=true
+    - WITH_PYSPARK=true
+    - DIST=alpine
+
+  - services: docker
+    env:
+    - SPARK_VERSION=2.4.1
+    - HADOOP_VERSION=2.7.3
+    - AWS_JAVA_SDK_VERSION=1.7.4
+    - WITH_HIVE=true
+    - WITH_PYSPARK=true
+    - DIST=alpine
+
+  - services: docker
+    env:
     - SPARK_VERSION=2.4.0
     - HADOOP_VERSION=3.1.0
     - AWS_JAVA_SDK_VERSION=1.11.271
+    - WITH_HIVE=true
+    - WITH_PYSPARK=true
+    - DIST=alpine
+
+  - services: docker
+    env:
+    - SPARK_VERSION=2.4.0
+    - HADOOP_VERSION=2.7.3
+    - AWS_JAVA_SDK_VERSION=1.7.4
     - WITH_HIVE=true
     - WITH_PYSPARK=true
     - DIST=alpine
@@ -238,6 +319,33 @@ matrix:
   - services: docker
     env:
     - SPARK_VERSION=2.1.0
+    - HADOOP_VERSION=2.7.3
+    - AWS_JAVA_SDK_VERSION=1.7.4
+    - WITH_HIVE=true
+    - WITH_PYSPARK=true
+    - DIST=alpine
+
+  - services: docker
+    env:
+    - SPARK_VERSION=2.0.2
+    - HADOOP_VERSION=2.7.3
+    - AWS_JAVA_SDK_VERSION=1.7.4
+    - WITH_HIVE=true
+    - WITH_PYSPARK=true
+    - DIST=alpine
+
+  - services: docker
+    env:
+    - SPARK_VERSION=2.0.1
+    - HADOOP_VERSION=2.7.3
+    - AWS_JAVA_SDK_VERSION=1.7.4
+    - WITH_HIVE=true
+    - WITH_PYSPARK=true
+    - DIST=alpine
+
+  - services: docker
+    env:
+    - SPARK_VERSION=2.0.0
     - HADOOP_VERSION=2.7.3
     - AWS_JAVA_SDK_VERSION=1.7.4
     - WITH_HIVE=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -158,7 +158,7 @@ matrix:
     - HADOOP_VERSION=2.7.3
     - AWS_JAVA_SDK_VERSION=1.7.4
     - WITH_HIVE=true
-    - WITH_PYSPARK=true
+    - WITH_PYSPARK=false
     - DIST=debian
 
   - services: docker
@@ -167,7 +167,7 @@ matrix:
     - HADOOP_VERSION=2.7.3
     - AWS_JAVA_SDK_VERSION=1.7.4
     - WITH_HIVE=true
-    - WITH_PYSPARK=true
+    - WITH_PYSPARK=false
     - DIST=debian
 
   - services: docker
@@ -176,7 +176,7 @@ matrix:
     - HADOOP_VERSION=2.7.3
     - AWS_JAVA_SDK_VERSION=1.7.4
     - WITH_HIVE=true
-    - WITH_PYSPARK=true
+    - WITH_PYSPARK=false
     - DIST=debian
 
   # Alpine builds
@@ -331,7 +331,7 @@ matrix:
     - HADOOP_VERSION=2.7.3
     - AWS_JAVA_SDK_VERSION=1.7.4
     - WITH_HIVE=true
-    - WITH_PYSPARK=true
+    - WITH_PYSPARK=false
     - DIST=alpine
 
   - services: docker
@@ -340,7 +340,7 @@ matrix:
     - HADOOP_VERSION=2.7.3
     - AWS_JAVA_SDK_VERSION=1.7.4
     - WITH_HIVE=true
-    - WITH_PYSPARK=true
+    - WITH_PYSPARK=false
     - DIST=alpine
 
   - services: docker
@@ -349,7 +349,7 @@ matrix:
     - HADOOP_VERSION=2.7.3
     - AWS_JAVA_SDK_VERSION=1.7.4
     - WITH_HIVE=true
-    - WITH_PYSPARK=true
+    - WITH_PYSPARK=false
     - DIST=alpine
 
   

--- a/.travis.yml.tmpl
+++ b/.travis.yml.tmpl
@@ -13,8 +13,8 @@ matrix:
     - SPARK_VERSION={{ v.spark }}
     - HADOOP_VERSION={{ v.hadoop }}
     - AWS_JAVA_SDK_VERSION={{ v.aws_java_sdk }}
-    - WITH_HIVE=true
-    - WITH_PYSPARK=true
+    - WITH_HIVE={{ v.with_hive }}
+    - WITH_PYSPARK={{ v.with_pyspark }}
     - DIST=debian
 {% endfor %}
   # Alpine builds
@@ -24,8 +24,8 @@ matrix:
     - SPARK_VERSION={{ v.spark }}
     - HADOOP_VERSION={{ v.hadoop }}
     - AWS_JAVA_SDK_VERSION={{ v.aws_java_sdk }}
-    - WITH_HIVE=true
-    - WITH_PYSPARK=true
+    - WITH_HIVE={{ v.with_hive }}
+    - WITH_PYSPARK={{ v.with_pyspark }}
     - DIST=alpine
 {% endfor %}
   

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ python3 -m pip install --user jinja2-cli[yaml]
 Once installed, to generate the new `.travis.yml` file, run:
 
 ```bash
-jinja2 .travis.yml.tmpl vars.yml > .travis.yml
+./apply-vars.sh
 ```
 
 As such, it is generally only necessary to update `vars.yml` to generate for

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ how to derive this version number for Hadoop 3.1.0 is here:
 ## Generation of `.travis.yml`
 
 This requires `python3` and `pip`. This will allow the installation of
-`jinj2-cli`.
+`jinja2-cli`.
 
 Run the following:
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ This adds the following:
 - Google Cloud Storage SDK JAR
 - MariaDB JDBC Connector JAR
 
+Additionally, all Alpine builds have `gcompat` and `libc6-compat` installed to
+prevent `glibc` shared library related issues.
+
 ## AWS Java SDK Version Derivation
 
 The version of AWS Java SDK is dependent on the Hadoop version. An example of

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -30,7 +30,7 @@ RUN set -euo pipefail && \
     curl -LO https://downloads.mariadb.com/Connectors/java/connector-java-2.4.0/mariadb-java-client-2.4.0.jar; \
     cd -; \
     # Required for prevent snappy compression error because the shared lib is dependent on glibc
-    apk add --no-cache libc6-compat; \
+    apk add --no-cache gcompat libc6-compat; \
     # apt clean-up
     apk del \
         curl \

--- a/apply-vars.sh
+++ b/apply-vars.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env sh
+if ! which jinja2 >/dev/null; then
+    echo "Run \"python3 -m pip install --user jinja2-cli[yaml]\" to install jinja2 first."
+fi
+
+jinja2 .travis.yml.tmpl vars.yml > .travis.yml
+echo "DONE!"

--- a/vars.yml
+++ b/vars.yml
@@ -99,16 +99,16 @@ versions:
   hadoop:       2.7.3
   aws_java_sdk: 1.7.4
   with_hive:    "true"
-  with_pyspark: "true"
+  with_pyspark: "false"
 
 - spark:        2.0.1
   hadoop:       2.7.3
   aws_java_sdk: 1.7.4
   with_hive:    "true"
-  with_pyspark: "true"
+  with_pyspark: "false"
 
 - spark:        2.0.0
   hadoop:       2.7.3
   aws_java_sdk: 1.7.4
   with_hive:    "true"
-  with_pyspark: "true"
+  with_pyspark: "false"

--- a/vars.yml
+++ b/vars.yml
@@ -1,65 +1,114 @@
 versions:
+- spark:        2.4.1
+  hadoop:       3.1.0
+  aws_java_sdk: 1.11.271
+  with_hive:    "true"
+  with_pyspark: "true"
+
+- spark:        2.4.1
+  hadoop:       2.7.3
+  aws_java_sdk: 1.7.4
+  with_hive:    "true"
+  with_pyspark: "true"
+
 - spark:        2.4.0
   hadoop:       3.1.0
   aws_java_sdk: 1.11.271
+  with_hive:    "true"
+  with_pyspark: "true"
+
+- spark:        2.4.0
+  hadoop:       2.7.3
+  aws_java_sdk: 1.7.4
+  with_hive:    "true"
+  with_pyspark: "true"
 
 - spark:        2.3.3
   hadoop:       2.7.3
   aws_java_sdk: 1.7.4
+  with_hive:    "true"
+  with_pyspark: "true"
 
 - spark:        2.3.2
   hadoop:       2.7.3
   aws_java_sdk: 1.7.4
+  with_hive:    "true"
+  with_pyspark: "true"
 
 - spark:        2.3.1
   hadoop:       2.7.3
   aws_java_sdk: 1.7.4
+  with_hive:    "true"
+  with_pyspark: "true"
 
 - spark:        2.3.0
   hadoop:       2.7.3
   aws_java_sdk: 1.7.4
+  with_hive:    "true"
+  with_pyspark: "true"
 
 - spark:        2.2.3
   hadoop:       2.7.3
   aws_java_sdk: 1.7.4
+  with_hive:    "true"
+  with_pyspark: "true"
 
 - spark:        2.2.2
   hadoop:       2.7.3
   aws_java_sdk: 1.7.4
+  with_hive:    "true"
+  with_pyspark: "true"
 
 - spark:        2.2.1
   hadoop:       2.7.3
   aws_java_sdk: 1.7.4
+  with_hive:    "true"
+  with_pyspark: "true"
 
 - spark:        2.2.0
   hadoop:       2.7.3
   aws_java_sdk: 1.7.4
+  with_hive:    "true"
+  with_pyspark: "true"
 
 - spark:        2.1.3
   hadoop:       2.7.3
   aws_java_sdk: 1.7.4
+  with_hive:    "true"
+  with_pyspark: "true"
 
 - spark:        2.1.2
   hadoop:       2.7.3
   aws_java_sdk: 1.7.4
+  with_hive:    "true"
+  with_pyspark: "true"
 
 - spark:        2.1.1
   hadoop:       2.7.3
   aws_java_sdk: 1.7.4
+  with_hive:    "true"
+  with_pyspark: "true"
 
 - spark:        2.1.0
   hadoop:       2.7.3
   aws_java_sdk: 1.7.4
+  with_hive:    "true"
+  with_pyspark: "true"
 
-# These do not support the install step the same way the newer versions do
-# - spark:        2.0.2
-#   hadoop:       2.7.3
-#   aws_java_sdk: 1.7.4
+- spark:        2.0.2
+  hadoop:       2.7.3
+  aws_java_sdk: 1.7.4
+  with_hive:    "true"
+  with_pyspark: "true"
 
-# - spark:        2.0.1
-#   hadoop:       2.7.3
-#   aws_java_sdk: 1.7.4
+- spark:        2.0.1
+  hadoop:       2.7.3
+  aws_java_sdk: 1.7.4
+  with_hive:    "true"
+  with_pyspark: "true"
 
-# - spark:        2.0.0
-#   hadoop:       2.7.3
-#   aws_java_sdk: 1.7.4
+- spark:        2.0.0
+  hadoop:       2.7.3
+  aws_java_sdk: 1.7.4
+  with_hive:    "true"
+  with_pyspark: "true"


### PR DESCRIPTION
- Also include `2.0.z` version without `pyspark`.
- Add `gcompat` for Alpine.